### PR TITLE
Implement Partition::readFooterPartition

### DIFF
--- a/libMXF++/File.h
+++ b/libMXF++/File.h
@@ -71,6 +71,7 @@ public:
     const std::vector<Partition*>& getPartitions() const { return _partitions; }
 
     bool readHeaderPartition();
+    Partition* readFooterPartition();  // Caller takes ownership
     bool readPartitions();
     void readNextPartition(const mxfKey *key, uint64_t len);
 


### PR DESCRIPTION
Part of https://github.com/bbc/bmx/pull/15

Returns a new Partition object owned by the caller. Doesn't change the _partitions list if a header partition was already read.